### PR TITLE
Refactor for safer outputPath handling

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,24 +1,23 @@
-const patternPresent = require('./lib/spotPattern.js');
+const spotPattern = require('./lib/spotPattern.js');
 const extractMatches = require('./lib/extractMatches.js');
 const buildEmbed = require('./lib/buildEmbed.js');
 const pluginDefaults = require('./lib/pluginDefaults.js');
 
 module.exports = function(eleventyConfig, options) {
   const pluginConfig = Object.assign(pluginDefaults, options);
-  eleventyConfig.addTransform("embedTikTok", async (content, outputPath) => {
-    if (!outputPath.endsWith(".html")) {
+  eleventyConfig.addTransform("embedVimeo", async (content, outputPath) => {
+    if (outputPath && outputPath.endsWith(".html")) {
+      let matches = spotPattern(content);
+      if (!matches) {
+        return content;
+      }
+      matches.forEach(function (stringToReplace, index) {
+        let media = extractMatches(stringToReplace);
+        let embedCode = buildEmbed(media, pluginConfig, index);
+        content = content.replace(stringToReplace, embedCode);
+      });
       return content;
     }
-    let matches = patternPresent(content);
-    if (!matches) {
-      return content;
-    }
-    // index is used to limit the number of script tags added to each page to one
-    matches.forEach(function(stringToReplace, index) {
-      let media = extractMatches(stringToReplace);
-      let embedCode = buildEmbed(media, pluginConfig, index);
-      content = content.replace(stringToReplace, embedCode);
-    });
     return content;
   });
 };


### PR DESCRIPTION
This PR refactors `outputPath` checking to better handle `null` cases (which can happen with XML files).